### PR TITLE
Edited shuffle() method so random number generation is now truly random with use of random seeds to generate the random int.

### DIFF
--- a/src/deck.go
+++ b/src/deck.go
@@ -3,8 +3,10 @@ package main
 import (
 	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"os"
 	"strings"
+	"time"
 )
 
 type deck []string
@@ -47,5 +49,15 @@ func newDeckFromFile(filename string) deck {
 		os.Exit(1)
 	}
 	s := strings.Split(string(bs), ",")
-	return deck(s)
+	return s
+}
+
+func (d deck) shuffle() {
+	s := rand.NewSource(time.Now().UnixNano())
+	r := rand.New(s)
+
+	for i := range d {
+		newPos := r.Intn(len(d) - 1)
+		d[i], d[newPos] = d[newPos], d[i]
+	}
 }

--- a/src/main.go
+++ b/src/main.go
@@ -1,7 +1,7 @@
 package main
 
 func main() {
-	cards := newDeckFromFile("my_cards")
-	// cards2 := newDeckFromFile("my_cards2") // throws error: file not found
+	cards := newDeck()
+	cards.shuffle()
 	cards.print()
 }


### PR DESCRIPTION
Edited shuffle() because before the rand.Intn() method which generates a random number was using a fixed seed (rand) to generate the int so we now used rand.NewSource and rand.New(source) to generate a truly random seed to use so now the order of shuffle will (statistically) never be the same.